### PR TITLE
Migrate to urllib3 so it now also works via proxy

### DIFF
--- a/script/LogsDownloader.py
+++ b/script/LogsDownloader.py
@@ -47,7 +47,7 @@ import threading
 import time
 import traceback
 import ssl
-import urllib2
+import urllib3
 import zlib
 from logging import handlers
 
@@ -548,49 +548,44 @@ class FileDownloader:
     def request_file_content(self, url, timeout=20):
         # default value
         response_content = ""
-        # if we are using a proxy server - read its configurations
-        if self.config.USE_PROXY == "YES":
-            proxy_dict = {"http": self.config.PROXY_SERVER, "https": self.config.PROXY_SERVER, "ftp": self.config.PROXY_SERVER}
-            proxy = urllib2.ProxyHandler(proxy_dict)
-            opener = urllib2.build_opener(proxy)
-            urllib2.install_opener(opener)
-        # build the request
-        request = urllib2.Request(url)
-        base64string = base64.encodestring("%s:%s" % (self.config.API_ID, self.config.API_KEY)).replace('\n', '')
-        request.add_header("Authorization", "Basic %s" % base64string)
+        # setup correct configuration
+        if self.config.USE_PROXY == "YES" and self.config.USE_CUSTOM_CA_FILE == "YES":
+            https = urllib3.ProxyManager(self.config.PROXY_SERVER, ca_certs=self.config.CUSTOM_CA_FILE, cert_reqs='CERT_REQUIRED', timeout=timeout)
+        elif self.config.USE_PROXY == "YES" and self.config.USE_CUSTOM_CA_FILE == "NO":
+            https = urllib3.ProxyManager(self.config.PROXY_SERVER, cert_reqs='CERT_REQUIRED', timeout=timeout)
+        elif self.config.USE_PROXY == "NO" and self.config.USE_CUSTOM_CA_FILE == "YES":
+            https = urllib3.PoolManager(ca_certs=self.config.CUSTOM_CA_FILE, cert_reqs='CERT_REQUIRED', timeout=timeout)
+        else:  # no proxy and no custom CA file
+            https = urllib3.PoolManager(cert_reqs='CERT_REQUIRED', timeout=timeout)
         try:
-            # open the connection to the URL
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-            if self.config.USE_CUSTOM_CA_FILE == "YES":
-                response = urllib2.urlopen(request, timeout=timeout, cafile=self.config.CUSTOM_CA_FILE, context=ctx)
-            else:
-                response = urllib2.urlopen(request, timeout=timeout, context=ctx)
-            # if we got a 200 OK response
-            if response.code == 200:
+            # build authentication header used for all requests
+            imperva_header = urllib3.make_headers(basic_auth='%s:%s' % (self.config.API_ID, self.config.API_KEY))
+            response = https.request('GET', url, headers=imperva_header)
+            # if we get a 200 OK response
+            if response.status == 200:
                 self.logger.info("Successfully downloaded file from URL %s" % url)
                 # read the response content
-                response_content = response.read()
-            # if we got another response code
+                response_content = response.data
+            # if we get another response code
+            elif response.status == 404:
+                self.logger.warning("Could not find file %s. Response code is %s", url, response.status)
+                return response_content
+            elif response.status == 401:
+                self.logger.error("Authorization error - Failed to download file %s. Response code is %s", url, response.status)
+                raise Exception("Authorization error")
+            elif response.status == 429:
+                self.logger.error("Rate limit exceeded - Failed to download file %s. Response code is %s", url, response.status)
+                raise Exception("Rate limit error")
             else:
-                self.logger.error("Failed to download file %s. Response code is %s. Info is %s", url, response.code, response.info())
+                self.logger.error("Failed to download file %s. Response code is %s. Headers are %s. Data is %s", url, response.status, response.headers, response.data)
             # close the response
             response.close()
             # return the content string
             return response_content
-        # if we got a 401 or 404 responses
-        except urllib2.HTTPError, e:
-            if e.code == 404:
-                self.logger.warning("Could not find file %s. Response code is %s", url, e.code)
-                return response_content
-            elif e.code == 401:
-                self.logger.error("Authorization error - Failed to download file %s. Response code is %s", url, e.code)
-                raise Exception("Authorization error")
-            elif e.code == 429:
-                self.logger.error("Rate limit exceeded - Failed to download file %s. Response code is %s", url, e.code)
-                raise Exception("Rate limit error")
-            else:
-                self.logger.error("An error has occur while making a open connection to %s. %s", url, str(e.code))
-                raise Exception("Connection error")
+        except urllib3.exceptions.HTTPError as e:
+            print('Request failed:', e)
+            self.logger.error("An error has occur while making a open connection to %s. %s", url, str(e.reason))
+            raise Exception("Connection error")
         # unexpected exception occurred
         except Exception:
             self.logger.error("An error has occur while making a open connection to %s. %s", url, traceback.format_exc())


### PR DESCRIPTION
I'm employed at an Imperva customer and was trying to implement this script on one of our Linux servers but needed to make it work via our corporate proxy. 

There's already an open issue (https://github.com/imperva/incapsula-logs-downloader/issues/4) that's been raised for the original code not working via a proxy but this was wrongly blamed on the user's proxy.

After hopelessly trying to make the original code work, I've found out that there is indeed a bug (https://stackoverflow.com/a/41878564) in the original urllib2 SSLContext code which means the proxy won't ever be used; the proposed workaround given in the SO link didn't work.

I've had to spend a bit of time to migrate the code from urllib2 to urllib3 so that it now works via a proxy whenever there is one configured in the "Settings.Config" configuration file and I've successfully tested it for a few days now and it's working very well; just like the original, my code will also work when no proxy has been specified and also caters for when a user has/hasn't specified a custom CA file.

It would be great if you could please accept this and merge so other customers don't have to face this same issue in their environments.

Razvan Ragazan